### PR TITLE
Fix resize handler when no renderer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -194,8 +194,8 @@ function getBaseName(): string{
     return polytopeTable[series][subclass];
 }
 
-var renderer: THREE.WebGLRenderer;
-var camera: THREE.PerspectiveCamera;
+var renderer: THREE.WebGLRenderer | null = null;
+var camera: THREE.PerspectiveCamera | null = null;
 var polytope: pt.Polytope;
 var animationFrame;
 //４次元回転のための行列
@@ -284,16 +284,17 @@ function init(prePolytope:Object, mode:string="Solid"): void{
 }
 
 function onResize() {
+    if (!renderer || !camera) {
+        return;
+    }
     // サイズを取得
     const width = window.innerWidth;
     const height = window.innerHeight;
-    const size = Math.floor(Math.min(width,height));
+    const size = Math.floor(Math.min(width, height));
 
     // レンダラーのサイズを調整する
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(size, size);
-
-    //contents.style.width = size+"px";
 
     // カメラのアスペクト比を正す
     camera.aspect = 1;


### PR DESCRIPTION
## Summary
- guard against resize events firing before initialization
- allow renderer and camera to start as `null`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'three')*

------
https://chatgpt.com/codex/tasks/task_e_684bb2ebf4e08328b50750287a3b1005